### PR TITLE
Add created at updated at

### DIFF
--- a/src/main/java/io/github/codenilson/lavava2025/Lavava2025Application.java
+++ b/src/main/java/io/github/codenilson/lavava2025/Lavava2025Application.java
@@ -2,7 +2,9 @@ package io.github.codenilson.lavava2025;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class Lavava2025Application {
 

--- a/src/main/java/io/github/codenilson/lavava2025/entities/Player.java
+++ b/src/main/java/io/github/codenilson/lavava2025/entities/Player.java
@@ -1,11 +1,14 @@
 package io.github.codenilson.lavava2025.entities;
 
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;
@@ -27,12 +30,22 @@ public class Player {
 
     @Column(unique = true, nullable = false)
     private String userName;
+
+    @Column(nullable = false)
     private String passWord;
 
     @OneToMany(mappedBy = "id.player")
     private Set<PlayerTeam> teams = new HashSet<>();
 
     private boolean active;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
 
     public Player() {
     }
@@ -73,6 +86,14 @@ public class Player {
 
     public void setActive(boolean active) {
         this.active = active;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
     }
 
     @Override

--- a/src/main/java/io/github/codenilson/lavava2025/entities/PlayerTeam.java
+++ b/src/main/java/io/github/codenilson/lavava2025/entities/PlayerTeam.java
@@ -1,14 +1,31 @@
 package io.github.codenilson.lavava2025.entities;
 
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import io.github.codenilson.lavava2025.entities.pks.PlayerTeamPk;
+import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 public class PlayerTeam {
 
     @EmbeddedId
     private PlayerTeamPk id = new PlayerTeamPk();
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
 
     public PlayerTeam() {
     }
@@ -32,6 +49,14 @@ public class PlayerTeam {
 
     public void setTeam(Team team) {
         this.id.setTeam(team);
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
     }
 
     @Override

--- a/src/main/java/io/github/codenilson/lavava2025/entities/Team.java
+++ b/src/main/java/io/github/codenilson/lavava2025/entities/Team.java
@@ -44,6 +44,14 @@ public class Team {
         return id;
     }
 
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
     @Transient
     public Set<Player> getPlayers() {
         return players.stream().map(PlayerTeam::getPlayer).collect(Collectors.toSet());

--- a/src/main/java/io/github/codenilson/lavava2025/entities/Team.java
+++ b/src/main/java/io/github/codenilson/lavava2025/entities/Team.java
@@ -1,10 +1,17 @@
 package io.github.codenilson.lavava2025.entities;
 
+import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -12,6 +19,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Transient;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 public class Team {
 
     @Id
@@ -20,6 +28,14 @@ public class Team {
 
     @OneToMany(mappedBy = "id.team")
     private Set<PlayerTeam> players;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
 
     public Team() {
     }
@@ -32,7 +48,5 @@ public class Team {
     public Set<Player> getPlayers() {
         return players.stream().map(PlayerTeam::getPlayer).collect(Collectors.toSet());
     }
-    
 
-    // private String name;
 }

--- a/src/test/java/io/github/codenilson/lavava2025/repositories/PlayerRepositoryTest.java
+++ b/src/test/java/io/github/codenilson/lavava2025/repositories/PlayerRepositoryTest.java
@@ -20,8 +20,10 @@ public class PlayerRepositoryTest {
     public void testFindByUserName() {
         // Given
         String userName = "testUser";
+        String passWord = "example01";
         Player player = new Player();
         player.setUserName(userName);
+        player.setPassWord(passWord);
         playerRepository.save(player);
 
         // When


### PR DESCRIPTION
This pull request introduces auditing functionality to the project by enabling JPA auditing and adding audit fields (`createdAt`, `updatedAt`) to several entity classes. Additionally, it includes updates to a test case to accommodate changes in the `Player` entity.

### Auditing functionality:

* [`src/main/java/io/github/codenilson/lavava2025/Lavava2025Application.java`](diffhunk://#diff-8691d7d919324f85483b31480efad82a73c60bddff4eee1afb365ecea87b6b40R5-R7): Enabled JPA auditing by adding the `@EnableJpaAuditing` annotation to the main application class.
* [`src/main/java/io/github/codenilson/lavava2025/entities/Player.java`](diffhunk://#diff-e86d02f692668a627b6c9337ad896f97732bd53eaf3fa0b55ad6a1c9ccc9c52dR3-R11): Added `createdAt` and `updatedAt` fields with the `@CreatedDate` and `@LastModifiedDate` annotations, respectively. Updated the class to include auditing via `AuditingEntityListener`. [[1]](diffhunk://#diff-e86d02f692668a627b6c9337ad896f97732bd53eaf3fa0b55ad6a1c9ccc9c52dR3-R11) [[2]](diffhunk://#diff-e86d02f692668a627b6c9337ad896f97732bd53eaf3fa0b55ad6a1c9ccc9c52dR33-R49) [[3]](diffhunk://#diff-e86d02f692668a627b6c9337ad896f97732bd53eaf3fa0b55ad6a1c9ccc9c52dR91-R98)
* [`src/main/java/io/github/codenilson/lavava2025/entities/PlayerTeam.java`](diffhunk://#diff-fc908ae9869f88e1c571df04c1db6fdd7bd7779173c17c6cd5994268ede2980bR3-R29): Added audit fields (`createdAt`, `updatedAt`) and enabled auditing for the `PlayerTeam` entity using `AuditingEntityListener`. [[1]](diffhunk://#diff-fc908ae9869f88e1c571df04c1db6fdd7bd7779173c17c6cd5994268ede2980bR3-R29) [[2]](diffhunk://#diff-fc908ae9869f88e1c571df04c1db6fdd7bd7779173c17c6cd5994268ede2980bR54-R61)
* [`src/main/java/io/github/codenilson/lavava2025/entities/Team.java`](diffhunk://#diff-53f1ec1ca1dccb7643d5f7d7f192b516b9c1341aea852755fd1f206117ac5e61R3-R22): Introduced audit fields (`createdAt`, `updatedAt`) and enabled auditing for the `Team` entity with `AuditingEntityListener`. [[1]](diffhunk://#diff-53f1ec1ca1dccb7643d5f7d7f192b516b9c1341aea852755fd1f206117ac5e61R3-R22) [[2]](diffhunk://#diff-53f1ec1ca1dccb7643d5f7d7f192b516b9c1341aea852755fd1f206117ac5e61R32-L37)

### Test updates:

* [`src/test/java/io/github/codenilson/lavava2025/repositories/PlayerRepositoryTest.java`](diffhunk://#diff-47399f9fd897ee34d037659ab835733a8474b040a69dd0897d859fb4811f695eR23-R26): Updated the `testFindByUserName` method to set the `passWord` field for the `Player` entity, reflecting the addition of the `passWord` field in the `Player` class.